### PR TITLE
fix: Añadir archivos de compilación de Gradle 2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.mygame'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.mygame"
+        minSdk 24
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,5 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id 'com.android.application' version '8.1.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "MyGame"
+include ':app'


### PR DESCRIPTION
Este commit añade los archivos de configuración de Gradle necesarios (`build.gradle` y `settings.gradle`) al proyecto.

Estos archivos faltaban, lo que impedía que Android Studio reconociera la estructura del proyecto y compilara el módulo 'app'.

Con estos archivos, el proyecto ahora puede ser sincronizado y compilado correctamente dentro de Android Studio.