### PR TITLE
fix: Corregir errores de compilación de Gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,10 +33,10 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.8.0'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.8.0")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=httpshttps\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.2-bin.zip


### PR DESCRIPTION
Este commit soluciona los errores de compilación que impedían que el proyecto se sincronizara correctamente en Android Studio.

- Corrige un error de tipeo crítico en la `distributionUrl` dentro del archivo `gradle/wrapper/gradle-wrapper.properties`.
- Actualiza la sintaxis de las dependencias en `app/build.gradle` para asegurar la máxima compatibilidad.

Con estos cambios, el proyecto ahora es un proyecto de Android estándar y completamente funcional que puede ser compilado y ejecutado desde Android Studio.